### PR TITLE
Use HZ CLI for Member Initialization

### DIFF
--- a/aws/hazelcast.yaml
+++ b/aws/hazelcast.yaml
@@ -1,8 +1,6 @@
 hazelcast:
   network:
       join:
-        multicast:
-          enabled: false
         aws:
           enabled: true
           # discovery_role is created by main terraform script

--- a/aws/main.tf
+++ b/aws/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "= 3.2.0"
+      version = " 3.22.0"
     }
   }
   required_version = ">= 0.13"
@@ -156,9 +156,10 @@ resource "aws_instance" "hazelcast_member" {
   provisioner "remote-exec" {
     inline = [
       "while [ ! -f /var/lib/cloud/instance/boot-finished ]; do echo 'Waiting for cloud-init...'; sleep 1; done",
-      "sudo apt-get update",
-      "sudo apt-get -y install openjdk-8-jdk wget",
-      "sleep 30"
+      "wget -qO - https://bintray.com/user/downloadSubjectPublicKey?username=hazelcast | sudo apt-key add -",
+      "echo \"deb http://dl.bintray.com/hazelcast/deb stable main\" | sudo tee -a /etc/apt/sources.list",
+      "sudo apt update && sudo apt -y install hazelcast",
+      "sleep 10"
     ]
   }
 
@@ -166,9 +167,9 @@ resource "aws_instance" "hazelcast_member" {
     inline = [
       "cd /home/${var.aws_ssh_user}",
       "chmod 0755 start_aws_hazelcast_member.sh",
-      "./start_aws_hazelcast_member.sh ${var.hazelcast_version} ${var.hazelcast_aws_version} ${var.aws_region} ${var.aws_tag_key} ${var.aws_tag_value} ${var.aws_connection_retries} ${aws_iam_role.discovery_role.name}",
+      "./start_aws_hazelcast_member.sh ${var.aws_region} ${var.aws_tag_key} ${var.aws_tag_value} ${var.aws_connection_retries} ${aws_iam_role.discovery_role.name}",
       "sleep 10",
-      "tail -n 10 ./logs/hazelcast.logs"
+      "tail -10 /home/${var.aws_ssh_user}/hazelcast.stdout.log"
     ]
   }
 }
@@ -210,7 +211,7 @@ resource "aws_instance" "hazelcast_mancenter" {
       "while [ ! -f /var/lib/cloud/instance/boot-finished ]; do echo 'Waiting for cloud-init...'; sleep 1; done",
       "sudo apt-get update",
       "sudo apt-get -y install openjdk-8-jdk wget unzip",
-      "sleep 30"
+      "sleep 10"
     ]
   }
 

--- a/aws/main.tf
+++ b/aws/main.tf
@@ -169,7 +169,7 @@ resource "aws_instance" "hazelcast_member" {
       "chmod 0755 start_aws_hazelcast_member.sh",
       "./start_aws_hazelcast_member.sh ${var.aws_region} ${var.aws_tag_key} ${var.aws_tag_value} ${var.aws_connection_retries} ${aws_iam_role.discovery_role.name}",
       "sleep 10",
-      "tail -10 /home/${var.aws_ssh_user}/hazelcast.stdout.log"
+      "tail -n 10 /home/${var.aws_ssh_user}/hazelcast.stdout.log"
     ]
   }
 }

--- a/aws/scripts/start_aws_hazelcast_member.sh
+++ b/aws/scripts/start_aws_hazelcast_member.sh
@@ -1,37 +1,11 @@
 #!/bin/bash
 set -x
 
-HZ_VERSION=$1
-AWS_VERSION=$2
-
-REGION=$3
-TAG_KEY=$4
-TAG_VALUE=$5
-CONN_RETRIES=$6
-IAM_ROLE=$7
-
-HZ_JAR_URL=https://repo1.maven.org/maven2/com/hazelcast/hazelcast/${HZ_VERSION}/hazelcast-${HZ_VERSION}.jar
-AWS_JAR_URL=https://repo1.maven.org/maven2/com/hazelcast/hazelcast-aws/${AWS_VERSION}/hazelcast-aws-${AWS_VERSION}.jar
-
-mkdir -p ${HOME}/jars
-mkdir -p ${HOME}/logs
-
-pushd ${HOME}/jars
-    echo "Downloading JARs..."
-    if wget -q "$HZ_JAR_URL"; then
-        echo "Hazelcast JAR downloaded succesfully."
-    else
-        echo "Hazelcast JAR could NOT be downloaded!"
-        exit 1;
-    fi
-
-    if wget -q "$AWS_JAR_URL"; then
-        echo "AWS Plugin JAR downloaded succesfully."
-    else
-        echo "AWS Plugin JAR could NOT be downloaded!"
-        exit 1;
-    fi
-popd
+REGION=$1
+TAG_KEY=$2
+TAG_VALUE=$3
+CONN_RETRIES=$4
+IAM_ROLE=$5
 
 sed -i -e "s/REGION/${REGION}/g" ${HOME}/hazelcast.yaml
 sed -i -e "s/TAG_KEY/${TAG_KEY}/g" ${HOME}/hazelcast.yaml
@@ -39,8 +13,7 @@ sed -i -e "s/TAG_VALUE/${TAG_VALUE}/g" ${HOME}/hazelcast.yaml
 sed -i -e "s/CONN_RETRIES/${CONN_RETRIES}/g" ${HOME}/hazelcast.yaml
 sed -i -e "s/IAM_ROLE/${IAM_ROLE}/g" ${HOME}/hazelcast.yaml
 
-CLASSPATH="${HOME}/jars/hazelcast-${HZ_VERSION}.jar:${HOME}/jars/hazelcast-aws-${AWS_VERSION}.jar"
-nohup java -cp ${CLASSPATH} -server com.hazelcast.core.server.HazelcastMemberStarter &>> ${HOME}/logs/hazelcast.logs &
+nohup hz start -c ${HOME}/hazelcast.yaml >> ${HOME}/hazelcast.stdout.log 2>> ${HOME}/hazelcast.stderr.log &
 sleep 5
 
 

--- a/aws/terraform.tfvars
+++ b/aws/terraform.tfvars
@@ -1,8 +1,8 @@
 # key pair name to be assigned to EC2 instance
-aws_key_name = "id_rsa"
+aws_key_name = #"id_rsa"
 
 # local path of public and private key file for SSH connection - local_key_path/aws_key_name
-local_key_path = "~/.ssh"
+local_key_path = #"~/.ssh"
 
 
 ########### Optional ############

--- a/aws/terraform.tfvars
+++ b/aws/terraform.tfvars
@@ -1,8 +1,8 @@
 # key pair name to be assigned to EC2 instance
-aws_key_name = #"id_rsa"
+aws_key_name = "id_rsa"
 
 # local path of public and private key file for SSH connection - local_key_path/aws_key_name
-local_key_path = #"~/.ssh"
+local_key_path = "~/.ssh"
 
 
 ########### Optional ############
@@ -11,14 +11,12 @@ member_count = "2"
 # If you are using free tier, using aws_instance_type other than "t2.micro" or "t3.micro" will cost money.
 aws_instance_type      = "t2.micro"
 aws_region             = "eu-central-1"
-aws_tag_key            = "Category"
-aws_tag_value          = "hazelcast-aws-discovery"
+aws_tag_key            = "hz-guide"
+aws_tag_value          = "terraform"
 aws_connection_retries = "3"
 
 prefix                      = "hazelcast"
-hazelcast_version           = "4.0"
-hazelcast_aws_version       = "3.3"
-hazelcast_mancenter_version = "4.2020.08"
+hazelcast_mancenter_version = "4.2020.12"
 
 # Username to use when connecting to VMs. Do not change this if you are using ubuntu images.
 aws_ssh_user = "ubuntu"

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -44,19 +44,9 @@ variable "aws_connection_retries" {
   default = "3"
 }
 
-variable "hazelcast_version" {
-  type    = string
-  default = "4.0"
-}
-
-variable "hazelcast_aws_version" {
-  type    = string
-  default = "3.3"
-}
-
 variable "hazelcast_mancenter_version" {
   type    = string
-  default = "4.2020.08"
+  default = "4.2020.12"
 }
 
 variable "aws_ssh_user" {

--- a/azure/hazelcast.yaml
+++ b/azure/hazelcast.yaml
@@ -1,8 +1,6 @@
 hazelcast:
   network:
     join:
-      multicast:
-        enabled: false
       azure:
         enabled: true
         tag: TAG_KEY=TAG_VALUE

--- a/azure/main.tf
+++ b/azure/main.tf
@@ -75,8 +75,8 @@ data "azurerm_subscription" "primary" {}
 
 #Assign role to the user assigned managed identity
 resource "azurerm_role_assignment" "reader" {
-  scope        = data.azurerm_subscription.primary.id
-  principal_id = azurerm_user_assigned_identity.hazelcast_reader.principal_id
+  scope              = data.azurerm_subscription.primary.id
+  principal_id       = azurerm_user_assigned_identity.hazelcast_reader.principal_id
   role_definition_id = azurerm_role_definition.reader.id
 }
 
@@ -159,9 +159,10 @@ resource "azurerm_linux_virtual_machine" "hazelcast_member" {
   provisioner "remote-exec" {
     inline = [
       "while [ ! -f /var/lib/cloud/instance/boot-finished ]; do echo 'Waiting for cloud-init...'; sleep 1; done",
-      "sudo apt-get update",
-      "sudo apt-get -y install openjdk-8-jdk wget",
-      "sleep 30"
+      "wget -qO - https://bintray.com/user/downloadSubjectPublicKey?username=hazelcast | sudo apt-key add -",
+      "echo \"deb http://dl.bintray.com/hazelcast/deb stable main\" | sudo tee -a /etc/apt/sources.list",
+      "sudo apt update && sudo apt -y install hazelcast",
+      "sleep 10"
     ]
   }
 
@@ -169,9 +170,9 @@ resource "azurerm_linux_virtual_machine" "hazelcast_member" {
     inline = [
       "cd /home/${var.azure_ssh_user}",
       "chmod 0755 start_azure_hazelcast_member.sh",
-      "./start_azure_hazelcast_member.sh ${var.hazelcast_version} ${var.hazelcast_azure_version} ${var.azure_tag_key} ${var.azure_tag_value}",
-      "sleep 30",
-      "tail -n 10 ./logs/hazelcast.logs"
+      "./start_azure_hazelcast_member.sh ${var.azure_tag_key} ${var.azure_tag_value}",
+      "sleep 10",
+      "tail -n 10 /home/${var.azure_ssh_user}/hazelcast.stdout.log"
     ]
   }
 
@@ -236,7 +237,7 @@ resource "azurerm_linux_virtual_machine" "hazelcast_mancenter" {
       "while [ ! -f /var/lib/cloud/instance/boot-finished ]; do echo 'Waiting for cloud-init...'; sleep 1; done",
       "sudo apt-get update",
       "sudo apt-get -y install openjdk-8-jdk wget unzip",
-      "sleep 30"
+      "sleep 10"
     ]
   }
 

--- a/azure/scripts/start_azure_hazelcast_member.sh
+++ b/azure/scripts/start_azure_hazelcast_member.sh
@@ -1,37 +1,12 @@
 #!/bin/bash
 set -x
 
-HZ_VERSION=$1
-AZURE_VERSION=$2
-TAG_KEY=$3
-TAG_VALUE=$4
+TAG_KEY=$1
+TAG_VALUE=$2
 
-HZ_JAR_URL=https://repo1.maven.org/maven2/com/hazelcast/hazelcast/${HZ_VERSION}/hazelcast-${HZ_VERSION}.jar
-AZURE_JAR_URL=https://repo1.maven.org/maven2/com/hazelcast/hazelcast-azure/${AZURE_VERSION}/hazelcast-azure-${AZURE_VERSION}.jar
-
-mkdir -p ${HOME}/jars
-mkdir -p ${HOME}/logs
-
-pushd ${HOME}/jars
-    echo "Downloading JARs..."
-    if wget -q "$HZ_JAR_URL"; then
-        echo "Hazelcast JAR downloaded succesfully."
-    else
-        echo "Hazelcast JAR could NOT be downloaded!"
-        exit 1;
-    fi
-
-    if wget -q "$AZURE_JAR_URL"; then
-        echo "AZURE Plugin JAR downloaded succesfully."
-    else
-        echo "AZURE Plugin JAR could NOT be downloaded!"
-        exit 1;
-    fi
-popd
 
 sed -i -e "s/TAG_KEY/${TAG_KEY}/g" ${HOME}/hazelcast.yaml
 sed -i -e "s/TAG_VALUE/${TAG_VALUE}/g" ${HOME}/hazelcast.yaml
 
-CLASSPATH="${HOME}/jars/hazelcast-${HZ_VERSION}.jar:${HOME}/jars/hazelcast-azure-${AZURE_VERSION}.jar"
-nohup java -cp ${CLASSPATH} -server com.hazelcast.core.server.HazelcastMemberStarter &>> ${HOME}/logs/hazelcast.logs &
+nohup hz start -c ${HOME}/hazelcast.yaml >> ${HOME}/hazelcast.stdout.log 2>> ${HOME}/hazelcast.stderr.log &
 sleep 5

--- a/azure/terraform.tfvars
+++ b/azure/terraform.tfvars
@@ -1,8 +1,8 @@
 # key name to be assigned to Azure Compute instances
-azure_key_name = "id_rsa"
+azure_key_name = #"id_rsa"
 
 # local path of private key file for SSH connection - local_key_path/azure_key_name
-local_key_path = "~/.ssh"
+local_key_path = #"~/.ssh"
 
 
 
@@ -11,7 +11,8 @@ location            = "central us"
 azure_instance_type = "Standard_B1ms"
 
 member_count = "2"
-prefix                      = "hazelcast-test"
+
+prefix                      = "hazelcast"
 hazelcast_mancenter_version = "4.2020.12"
 
 # Username to use when connecting to VMs.

--- a/azure/terraform.tfvars
+++ b/azure/terraform.tfvars
@@ -1,8 +1,8 @@
 # key name to be assigned to Azure Compute instances
-azure_key_name = #"id_rsa"
+azure_key_name = "id_rsa"
 
 # local path of private key file for SSH connection - local_key_path/azure_key_name
-local_key_path = #"~/.ssh"
+local_key_path = "~/.ssh"
 
 
 
@@ -10,13 +10,9 @@ local_key_path = #"~/.ssh"
 location            = "central us"
 azure_instance_type = "Standard_B1ms"
 
-
 member_count = "2"
-
-prefix                      = "hazelcast"
-hazelcast_version           = "4.0.2"
-hazelcast_azure_version     = "2.1"
-hazelcast_mancenter_version = "4.2020.08"
+prefix                      = "hazelcast-test"
+hazelcast_mancenter_version = "4.2020.12"
 
 # Username to use when connecting to VMs.
 azure_tag_key = "hz-guide"

--- a/azure/variables.tf
+++ b/azure/variables.tf
@@ -19,18 +19,8 @@ variable "prefix" {
 }
 
 variable "member_count" {
-  type = number
+  type    = number
   default = "2"
-}
-
-variable "hazelcast_version" {
-  type    = string
-  default = "4.0.2"
-}
-
-variable "hazelcast_azure_version" {
-  type    = string
-  default = "2.1"
 }
 
 variable "hazelcast_mancenter_version" {
@@ -49,11 +39,11 @@ variable "azure_instance_type" {
 }
 
 variable "azure_tag_key" {
-  type = string
+  type    = string
   default = "hz-guide"
 }
 
 variable "azure_tag_value" {
-  type = string
+  type    = string
   default = "terraform"
 }

--- a/azure/variables.tf
+++ b/azure/variables.tf
@@ -25,7 +25,7 @@ variable "member_count" {
 
 variable "hazelcast_mancenter_version" {
   type    = string
-  default = "4.2020.08"
+  default = "4.2020.12"
 }
 
 variable "azure_ssh_user" {

--- a/gcp/hazelcast.yaml
+++ b/gcp/hazelcast.yaml
@@ -1,8 +1,6 @@
 hazelcast:
   network:
     join:
-      multicast:
-        enabled: false
       gcp:
         enabled: true
         label: LABEL_KEY=LABEL_VALUE

--- a/gcp/scripts/start_gcp_hazelcast_member.sh
+++ b/gcp/scripts/start_gcp_hazelcast_member.sh
@@ -1,37 +1,11 @@
 #!/bin/bash
 set -x
 
-HZ_VERSION=$1
-GCP_VERSION=$2
-LABEL_KEY=$3
-LABEL_VALUE=$4
-
-HZ_JAR_URL=https://repo1.maven.org/maven2/com/hazelcast/hazelcast/${HZ_VERSION}/hazelcast-${HZ_VERSION}.jar
-GCP_JAR_URL=https://repo1.maven.org/maven2/com/hazelcast/hazelcast-gcp/${GCP_VERSION}/hazelcast-gcp-${GCP_VERSION}.jar
-
-mkdir -p ${HOME}/jars
-mkdir -p ${HOME}/logs
-
-pushd ${HOME}/jars
-    echo "Downloading JARs..."
-    if wget -q "$HZ_JAR_URL"; then
-        echo "Hazelcast JAR downloaded succesfully."
-    else
-        echo "Hazelcast JAR could NOT be downloaded!"
-        exit 1;
-    fi
-
-    if wget -q "$GCP_JAR_URL"; then
-        echo "GCP Plugin JAR downloaded succesfully."
-    else
-        echo "GCP Plugin JAR could NOT be downloaded!"
-        exit 1;
-    fi
-popd
+LABEL_KEY=$1
+LABEL_VALUE=$2
 
 sed -i -e "s/LABEL_KEY/${LABEL_KEY}/g" ${HOME}/hazelcast.yaml
 sed -i -e "s/LABEL_VALUE/${LABEL_VALUE}/g" ${HOME}/hazelcast.yaml
 
-CLASSPATH="${HOME}/jars/hazelcast-${HZ_VERSION}.jar:${HOME}/jars/hazelcast-gcp-${GCP_VERSION}.jar:${HOME}/hazelcast.yaml"
-nohup java -cp ${CLASSPATH} -server com.hazelcast.core.server.HazelcastMemberStarter &>> ${HOME}/logs/hazelcast.logs &
+nohup hz start -c ${HOME}/hazelcast.yaml >> ${HOME}/hazelcast.stdout.log 2>> ${HOME}/hazelcast.stderr.log &
 sleep 5

--- a/gcp/terraform.tfvars
+++ b/gcp/terraform.tfvars
@@ -1,11 +1,11 @@
 # key name to be assigned to Google Compute instances
-gcp_key_name = #"id_rsa"
+gcp_key_name = "id_rsa"
 
 # local path of private key file for SSH connection - local_key_path/gcp_key_name
-local_key_path = #"~/.ssh"
+local_key_path = "~/.ssh"
 
 # ID of the project you want to use
-project_id = #"project_id"
+project_id = "hazelcast-33" #"project_id"
 
 ########### Optional ############
 
@@ -16,9 +16,7 @@ member_count      = "2"
 gcp_instance_type = "f1-micro"
 
 prefix                      = "hazelcast"
-hazelcast_version           = "4.0.2"
-hazelcast_gcp_version       = "2.1"
-hazelcast_mancenter_version = "4.2020.08"
+hazelcast_mancenter_version = "4.2020.12"
 
 gcp_label_key = "hz-guide"
 gcp_label_value = "terraform"

--- a/gcp/terraform.tfvars
+++ b/gcp/terraform.tfvars
@@ -1,11 +1,11 @@
 # key name to be assigned to Google Compute instances
-gcp_key_name = "id_rsa"
+gcp_key_name = #"id_rsa"
 
 # local path of private key file for SSH connection - local_key_path/gcp_key_name
-local_key_path = "~/.ssh"
+local_key_path = #"~/.ssh"
 
 # ID of the project you want to use
-project_id = "hazelcast-33" #"project_id"
+project_id =  #"project_id"
 
 ########### Optional ############
 

--- a/gcp/variables.tf
+++ b/gcp/variables.tf
@@ -35,7 +35,7 @@ variable "gcp_ssh_user" {
 
 variable "hazelcast_mancenter_version" {
   type    = string
-  default = "4.2020.08"
+  default = "4.2020.12"
 }
 
 variable "prefix" {

--- a/gcp/variables.tf
+++ b/gcp/variables.tf
@@ -10,11 +10,11 @@ variable "local_key_path" {
 
 # ID of the project you want to use
 variable "project_id" {
-  type    = string
+  type = string
 }
 
 variable "region" {
-  type = string
+  type    = string
   default = "us-central1"
 }
 
@@ -33,16 +33,6 @@ variable "gcp_ssh_user" {
   default = "ubuntu"
 }
 
-variable "hazelcast_version" {
-  type    = string
-  default = "4.0.2"
-}
-
-variable "hazelcast_gcp_version" {
-  type    = string
-  default = "2.1"
-}
-
 variable "hazelcast_mancenter_version" {
   type    = string
   default = "4.2020.08"
@@ -59,11 +49,11 @@ variable "gcp_instance_type" {
 }
 
 variable "gcp_label_key" {
-  type = string
+  type    = string
   default = "hz-guide"
 }
 
 variable "gcp_label_value" {
-  type = string
+  type    = string
   default = "terraform"
 }


### PR DESCRIPTION
Members were initialized by downloading necessary jars from the internet and running java command. With this PR VMs install HZ CLI and run `hz start -c hazelcast.yaml` to start the members.

HZ CLI doesn't support config files for management center, so I didn't make any changes to the management center initialization process. When they add that functionality we can update it too.

I also refactored the code and updated Terraform provider versions